### PR TITLE
Require CMake 2.8.7 or later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Changed by Vinicius Jarina (viniciusjarina@gmail.com)
 
 PROJECT ( lua CXX )
-CMAKE_MINIMUM_REQUIRED ( VERSION 2.8 )
+CMAKE_MINIMUM_REQUIRED ( VERSION 2.8.7 )
 
 IF (CMAKE_SIZEOF_VOID_P EQUAL 8)
 	SET (LIB_SUFFIX "64" CACHE STRING "Suffix of the directory name, e.g. 64 for lib64")


### PR DESCRIPTION
Version 2.8.2 of CMake does not support the `WORKING_DIRECTORY` argument to `add_test()`.  Bumped the required version to 2.8.7 so that a more informative and helpful error message is displayed on earlier versions, instead of pages of errors.
