### PR TITLE
Add arch parameter to i386.a make target.

### DIFF
--- a/ios_build/Makefile
+++ b/ios_build/Makefile
@@ -9,7 +9,7 @@ libLua52-x86_64.a:
 	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphonesimulator -arch x86_64 -configuration Release clean build
 	-mv $(PROJECT_ROOT)/build/Release-iphonesimulator/libLua_iPhone.a $@
 libLua52-i386.a:
-	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphonesimulator -configuration Release clean build
+	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphonesimulator -arch i386 -configuration Release clean build
 	-mv $(PROJECT_ROOT)/build/Release-iphonesimulator/libLua_iPhone.a $@
 libLua52-arm64.a:
 	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphoneos -arch arm64 -configuration Release clean build


### PR DESCRIPTION
On my iMac, it seems that the default arch is x86_64, so omitting the -arch parameter caused both x86_64 and i386 to build with the x86_64 architecture. Explicitly specifying the architecture for i386 fixes this issue.